### PR TITLE
Add Excel export for defects

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,10 @@
     "express": "^5.1.0",
     "multer": "^2.0.1",
     "pg": "^8.16.0",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "exceljs": "^4.3.0",
+    "canvas": "^2.11.2",
+    "heatmap.js": "^2.0.5"
   },
   "devDependencies": {
     "knex": "^3.1.0",

--- a/backend/src/controllers/export.js
+++ b/backend/src/controllers/export.js
@@ -1,0 +1,76 @@
+const knex = require('../db/knex');
+const ExcelJS = require('exceljs');
+const { createCanvas, loadImage } = require('canvas');
+const h337 = require('heatmap.js');
+const path = require('path');
+
+async function exportProjectDefects(req, res, next) {
+  try {
+    const projectId = req.params.id;
+    const images = await knex('images').where('project_id', projectId);
+
+    const workbook = new ExcelJS.Workbook();
+
+    for (const image of images) {
+      const worksheet = workbook.addWorksheet(image.filename || `Image ${image.id}`);
+      worksheet.columns = [
+        { header: 'Defect ID', key: 'id', width: 10 },
+        { header: 'X', key: 'x', width: 8 },
+        { header: 'Y', key: 'y', width: 8 },
+        { header: 'CBU', key: 'cbu', width: 20 },
+        { header: 'Part', key: 'part_id', width: 10 },
+        { header: 'Event', key: 'build_event_id', width: 10 },
+        { header: 'Type', key: 'defect_type_id', width: 10 },
+      ];
+
+      const defects = await knex('defects').where('image_id', image.id);
+      defects.forEach((d) => worksheet.addRow(d));
+
+      // Path to original image file
+      const filePath = path.resolve(__dirname, '../../uploads/defects', path.basename(image.url));
+      try {
+        const baseImg = await loadImage(filePath);
+        const canvas = createCanvas(baseImg.width, baseImg.height);
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(baseImg, 0, 0);
+
+        const heatCanvas = createCanvas(baseImg.width, baseImg.height);
+        const heat = h337.create({
+          container: heatCanvas,
+          radius: 60,
+          maxOpacity: 0.65,
+          minOpacity: 0.05,
+          blur: 0.9,
+        });
+        heat.setData({
+          max: 5,
+          data: defects.map((d) => ({ x: d.x, y: d.y, value: 1 })),
+        });
+        ctx.drawImage(heatCanvas, 0, 0);
+
+        const imgId = workbook.addImage({
+          buffer: canvas.toBuffer('image/png'),
+          extension: 'png',
+        });
+        worksheet.addImage(imgId, {
+          tl: { col: 8, row: 1 },
+          ext: { width: 400, height: 400 },
+        });
+      } catch (err) {
+        console.error('Error rendering heatmap', err);
+      }
+    }
+
+    res.setHeader(
+      'Content-Type',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    );
+    res.setHeader('Content-Disposition', 'attachment; filename="project-defects.xlsx"');
+    await workbook.xlsx.write(res);
+    res.end();
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { exportProjectDefects };

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -9,6 +9,7 @@ const {
   updateproject,
   deleteproject,
 } = require('../controllers/projects');
+const { exportProjectDefects } = require('../controllers/export');
 
 // GET    /api/projects        → list all projects
 // GET    /api/projects/:id    → get one project by its ID
@@ -18,6 +19,7 @@ const {
 
 router.get('/', listprojects);
 router.get('/:id', getprojectById);
+router.get('/:id/export', exportProjectDefects);
 router.post('/', createproject);
 router.put('/:id', updateproject);
 router.delete('/:id', deleteproject);

--- a/frontend/src/pages/DefectsReviewScreen.jsx
+++ b/frontend/src/pages/DefectsReviewScreen.jsx
@@ -65,6 +65,15 @@ export default function DefectsReviewScreen() {
         >
           ← Back to Project Select
         </Button>
+        <Button
+          variant="outlined"
+          sx={{ mb: 2, ml: 2 }}
+          onClick={() => {
+            window.location.href = `${process.env.REACT_APP_API_URL}/projects/${projectId}/export`;
+          }}
+        >
+          Download Excel
+        </Button>
 
         {images.length > 0 ? (
           <>


### PR DESCRIPTION
## Summary
- add exceljs, canvas and heatmap dependencies
- create export controller to generate workbook with heatmapped images
- expose `GET /api/projects/:id/export` endpoint
- add Download Excel button on Defects Review screen

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843741fffe4832b8344bae1f3f83e50