### PR TITLE
Add Pareto chart for defect analysis

### DIFF
--- a/backend/src/controllers/defects.js
+++ b/backend/src/controllers/defects.js
@@ -134,6 +134,42 @@ async function deleteDefect(req, res, next) {
   }
 }
 
+/**
+ * Get defect counts by defect type with optional filters
+ * GET /api/defects/summary?project_id=&build_event_id=&part_ids=1,2
+ */
+async function countByDefectType(req, res, next) {
+  try {
+    const { build_event_id, part_ids, project_id } = req.query;
+
+    const q = knex('defects as d')
+      .leftJoin('images as i', 'd.image_id', 'i.id')
+      .leftJoin('defect_types as dt', 'd.defect_type_id', 'dt.id')
+      .select('d.defect_type_id', 'dt.name as defect_type_name')
+      .count('* as count')
+      .groupBy('d.defect_type_id', 'dt.name')
+      .orderBy('count', 'desc');
+
+    if (build_event_id) {
+      q.where('d.build_event_id', build_event_id);
+    }
+
+    if (part_ids) {
+      const ids = part_ids.split(',').map((id) => parseInt(id, 10)).filter(Boolean);
+      if (ids.length) q.whereIn('d.part_id', ids);
+    }
+
+    if (project_id) {
+      q.where('i.project_id', project_id);
+    }
+
+    const rows = await q;
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+}
+
 async function uploadPhoto(req, res, next) {
   try {
     if (!req.file) {
@@ -152,5 +188,6 @@ module.exports = {
   createDefect,
   updateDefect,
   deleteDefect,
+  countByDefectType,
   uploadPhoto,
 };

--- a/backend/src/routes/defects.js
+++ b/backend/src/routes/defects.js
@@ -10,6 +10,7 @@ const {
   createDefect,
   updateDefect,
   deleteDefect,
+  countByDefectType,
   uploadPhoto,
 } = require('../controllers/defects');
 
@@ -29,6 +30,7 @@ const upload = multer({ storage });
 // PUT  /api/defects/:id         → update an existing defect
 // DELETE /api/defects/:id       → delete a defect
 
+router.get('/summary', countByDefectType);
 router.get('/', listDefects);
 router.get('/:id', getDefectById);
 router.post('/', createDefect);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,8 @@
     "exceljs": "^4.3.0",
     "file-saver": "^2.0.5",
     "html2canvas": "^1.4.1",
+    "chart.js": "^4.4.0",
+    "react-chartjs-2": "^5.2.0",
     "use-image": "^1.1.2",
     "web-vitals": "^2.1.4"
   },

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,7 @@ import ProjectSelectPage from './pages/ProjectSelectPage';
 // Import your existing screens:
 import EntryDefectScreen from './pages/EntryDefectScreen';
 import DefectsReviewScreen from './pages/DefectsReviewScreen';
+import ParetoChartScreen from './pages/ParetoChartScreen';
 
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import ZoneCreatorScreen from './pages/ZoneCreatorScreen';
@@ -14,6 +15,7 @@ function App() {
         <Route path="/projects/:projectId/entry-defect" element={<EntryDefectScreen />} />
         <Route path="/projects/:projectId/defects-review" element={<DefectsReviewScreen />} />
         <Route path="/projects/:projectId/zone-editor" element={<ZoneCreatorScreen />} />
+        <Route path="/projects/:projectId/pareto" element={<ParetoChartScreen />} />
         {/* Add other routes here */}
       </Routes>
     </Router>

--- a/frontend/src/pages/ParetoChartScreen.jsx
+++ b/frontend/src/pages/ParetoChartScreen.jsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  Box,
+  Typography,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  OutlinedInput,
+  Checkbox,
+  ListItemText,
+} from '@mui/material';
+import { Chart as ChartJS, BarElement, CategoryScale, LinearScale, LineElement, PointElement } from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import api from '../services/api';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, LineElement, PointElement);
+
+export default function ParetoChartScreen() {
+  const { projectId } = useParams();
+  const [buildEvents, setBuildEvents] = useState([]);
+  const [parts, setParts] = useState([]);
+  const [selectedEvent, setSelectedEvent] = useState('');
+  const [selectedParts, setSelectedParts] = useState([]);
+  const [summary, setSummary] = useState([]);
+
+  useEffect(() => {
+    api.get('/build-events').then(res => setBuildEvents(res.data));
+    api.get('/parts').then(res => setParts(res.data));
+  }, []);
+
+  useEffect(() => {
+    const params = { project_id: projectId };
+    if (selectedEvent) params.build_event_id = selectedEvent;
+    if (selectedParts.length) params.part_ids = selectedParts.join(',');
+    api.get('/defects/summary', { params }).then(res => setSummary(res.data));
+  }, [projectId, selectedEvent, selectedParts]);
+
+  const labels = summary.map(r => r.defect_type_name || r.defect_type_id);
+  const counts = summary.map(r => r.count);
+  const total = counts.reduce((a, b) => a + b, 0);
+  let cum = 0;
+  const cumulative = counts.map(c => {
+    cum += c;
+    return +(cum / total * 100).toFixed(2);
+  });
+
+  const data = {
+    labels,
+    datasets: [
+      {
+        type: 'bar',
+        label: 'Count',
+        data: counts,
+        backgroundColor: 'rgba(75,192,192,0.5)',
+      },
+      {
+        type: 'line',
+        label: 'Cumulative %',
+        data: cumulative,
+        borderColor: 'red',
+        backgroundColor: 'red',
+        yAxisID: 'y2',
+        tension: 0.1,
+      },
+    ],
+  };
+
+  const options = {
+    scales: {
+      y: { beginAtZero: true },
+      y2: {
+        beginAtZero: true,
+        max: 100,
+        position: 'right',
+        grid: { drawOnChartArea: false },
+        ticks: { callback: v => `${v}%` },
+      },
+    },
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h5" gutterBottom>Pareto of Defects</Typography>
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 2 }}>
+        <FormControl sx={{ minWidth: 180 }} size="small">
+          <InputLabel id="event-label">Event</InputLabel>
+          <Select
+            labelId="event-label"
+            label="Event"
+            value={selectedEvent}
+            onChange={e => setSelectedEvent(e.target.value)}
+          >
+            <MenuItem value="">All</MenuItem>
+            {buildEvents.map(ev => (
+              <MenuItem key={ev.id} value={ev.id}>{ev.name}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl sx={{ minWidth: 220 }} size="small">
+          <InputLabel id="parts-label">Parts</InputLabel>
+          <Select
+            multiple
+            labelId="parts-label"
+            label="Parts"
+            value={selectedParts}
+            onChange={e => setSelectedParts(e.target.value)}
+            input={<OutlinedInput label="Parts" />}
+            renderValue={selected => selected.map(id => {
+              const p = parts.find(pt => pt.id === id);
+              return p ? p.seat_part_number : id;
+            }).join(', ')}
+          >
+            {parts.map(p => (
+              <MenuItem key={p.id} value={p.id}>
+                <Checkbox checked={selectedParts.indexOf(p.id) > -1} />
+                <ListItemText primary={p.seat_part_number} />
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+      <Bar data={data} options={options} />
+    </Box>
+  );
+}
+

--- a/frontend/src/pages/ProjectSelectPage.jsx
+++ b/frontend/src/pages/ProjectSelectPage.jsx
@@ -65,16 +65,26 @@ function ProjectSelectPage() {
           >
             Defects Review Screen
             </Button>
-          <Button
-            variant="outlined"
-            onClick={() =>
-              navigate(`/projects/${selectedProjectId}/zone-editor`, {
-                state: { project: selectedProjectId },
-              })
-            }
-          >
-            Zone Editor
-          </Button>
+        <Button
+          variant="outlined"
+          onClick={() =>
+            navigate(`/projects/${selectedProjectId}/zone-editor`, {
+              state: { project: selectedProjectId },
+            })
+          }
+        >
+          Zone Editor
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={() =>
+            navigate(`/projects/${selectedProjectId}/pareto`, {
+              state: { project: selectedProjectId },
+            })
+          }
+        >
+          Pareto Chart
+        </Button>
         </Stack>
       )}
     </Box>


### PR DESCRIPTION
## Summary
- expose `/api/defects/summary` for aggregated defect counts
- allow project selection to open Pareto chart screen
- route new Pareto chart page in the front-end
- implement Pareto chart screen with event and part filters
- include chart.js dependencies

## Testing
- `npm test --silent --yes` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_684b3e083064832b9a95094cd707f577